### PR TITLE
testsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ First, read the data for one of the example datasets, here Atnasjø:
 
 ````julia
 path = joinpath(pathof(VannModels), "..", "data", "atnasjo")
-
 date, tair, prec, q_obs, frac_lus, frac_area, elev = load_data(path)
 ````
 
@@ -38,7 +37,6 @@ Second, compute potential evapotranspiration for the catchment:
 
 ````julia
 lat = 60.0
-
 epot = oudin(date, tair, lat, frac_area)
 ````
 
@@ -56,7 +54,6 @@ Start by specifying the time step length in hours and the time for the first inp
 
 ````julia
 tstep = 24.0
-
 tstart = date[1]
 ````
 
@@ -80,7 +77,6 @@ Again, start by specifying the time step length in hours and the time for the fi
 
 ````julia
 tstep = 24.0
-
 tstart = date[1]
 ````
 
@@ -88,9 +84,7 @@ Next specify a snow, glacier and subsurface component:
 
 ````julia
 snow = HbvLightSnow(tstep, tstart, frac_lus)
-
 glacier = NoGlacier()
-
 subsurf = Gr4j(tstep, tstart)
 ````
 
@@ -118,7 +112,6 @@ The model can be ran using the best-fit parameters with the following command:
 
 ````julia
 set_params!(model, param_tuned)
-
 q_sim = run_model(model, input)
 ````
 

--- a/test.jl
+++ b/test.jl
@@ -1,38 +1,20 @@
-
-
 using VannModels
 
-path = joinpath(pathof(VannModels), "..", "data", "atnasjo")
-
+path = joinpath(@__DIR__, "data", "atnasjo")
 date, tair, prec, q_obs, frac_lus, frac_area, elev = load_data(path)
-
 lat = 60.0
-
 epot = oudin(date, tair, lat, frac_area)
-
 input = InputPTE(date, prec, tair, epot)
-
 tstep = 24.0
-
 tstart = date[1]
-
 model = model_hbv_light(tstep, tstart, frac_lus)
-
 q_sim = run_model(model, input)
-
 
 snow = HbvLightSnow(tstep, tstart, frac_lus)
-
 glacier = NoGlacier()
-
 subsurf = Gr4j(tstep, tstart)
-
 model = ModelComp(snow, glacier, subsurf)
-
 q_sim = run_model(model, input)
-
 param_tuned = run_model_calib(model, input, q_obs, warmup = 1, verbose = :silent)
-
 set_params!(model, param_tuned)
-
 q_sim = run_model(model, input)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,4 +2,6 @@ using VannModels
 using Test
 using Dates
 
-include("solar_rad.jl")
+@testset begin "VannModels" begin
+    include("solar_rad.jl")
+end

--- a/test/solar_rad.jl
+++ b/test/solar_rad.jl
@@ -1,32 +1,27 @@
-date = DateTime(1980, 7, 20)
+using VannModels
+using Test
 
-doy = Dates.dayofyear(date)
+@testset "Solar radiation" begin
+    date = DateTime(1980, 7, 20)
+    doy = Dates.dayofyear(date)
+    lat = -23.7951
+    elev = 546.0
 
-lat = -23.7951
+    dr = VannModels.inverse_dist(doy)
+    @test dr ≈ 0.9688418122084714
 
-elev = 546.0
+    δ = VannModels.solar_decl(doy)
+    @test δ ≈ 0.35565253560155585
 
-dr = VannModels.inverse_dist(doy)
+    ω_s = VannModels.sunset_hour_angle(deg2rad(lat), δ)
+    @test ω_s ≈ 1.4062650741766252
 
-@test round(dr, digits=4) == 0.9688
+    N = VannModels.daylight_hours(ω_s)
+    @test N ≈ 10.743073816929636
 
-δ = VannModels.solar_decl(doy)
+    R_a = VannModels.extra_ter_rad(date, lat)
+    @test R_a ≈ 23.618220461289415
 
-@test round(δ, digits=4) == 0.3557
-
-ω_s = VannModels.sunset_hour_angle(deg2rad(lat), δ)
-
-@test round(ω_s, digits=4) == 1.4063
-
-N = VannModels.daylight_hours(ω_s)
-
-@test round(N, digits=4) == 10.7431
-
-R_a = VannModels.extra_ter_rad(date, lat)
-
-@test round(R_a, digits=4) == 23.6182
-
-R_so = VannModels.clear_sky_rad(date, lat, elev)
-
-@test round(R_so, digits=4) == 17.9716
-
+    R_so = VannModels.clear_sky_rad(date, lat, elev)
+    @test R_so ≈ 17.97157631340434
+end


### PR DESCRIPTION
Hi Jan,

This isn't much, but part of familiarizing myself with the code :) Will have more time later.
If you want I can remove the removal of double spacing. To me this is harder to read than single spaced:

```julia
""" Single model run for calibration. """
function calib_wrapper(param, model::AbstractModel, input::AbstractInput, var_obs, warmup)

    @assert 1 <= warmup <= length(var_obs)

    set_params!(model, param)

    init_states!(model, input.time[1])

    var_sim = run_model(model, input)

    1.0 - nse(var_sim[warmup:end], var_obs[warmup:end])

end
```

Of course I'm all for using whitespace to seperate logical blocks.